### PR TITLE
Update check_omd.py to python3 and added --heal functionality to automatically restart OMD services

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.vagrant
+__pycache__

--- a/README.md
+++ b/README.md
@@ -4,10 +4,12 @@
 
 ``check_omd`` is a Nagios / Icinga plugin for checking a particular [OMD](http://www.omdistro.org) site's services.
 
-# Requirements
+## Requirements
+
 I successfully tested the plugin with OMD site versions 1.20 to 2.70. As the plugin needs to be executed **by the site user**, a sudo rule is needed. A template (*``check_omd-sudo-template``*) is part of the repository.
 
-# Usage
+## Usage
+
 By default, the script checks all services of the site - it is also possible to exclude services if they are predicted to fail in your environment (*``-x`` / ``--exclude`` parameters*).
 
 The following parameters can be specified:
@@ -22,33 +24,40 @@ The following parameters can be specified:
 | `--version` | prints programm version and quits |
 
 ## Examples
+
 The following example indicates an running OMD site:
-```
-$ ./check_omd.py 
+
+```shell
+$ ./check_omd.py
 OK: OMD site 'stankowic' services are running.
 ```
 
 A site with a failed ``nagios`` service:
-```
-$ ./check_omd.py 
+
+```shell
+$ ./check_omd.py
 CRITICAL: OMD site 'hansel' has failed service(s): 'nagios'
 ```
 
 OMD site ``giertz`` with a well-known daemon, that's crashing sometimes:
-```
+
+```shell
 $ ./check_omd.py -x npcd
 OK: OMD site 'giertz' services are running.
 ```
 
 OMD site ``clpmchn``, excluding npcd from throwing critical states:
-```
+
+```shell
 $ ./check_omd.py -w npcd
 WARNING: OMD site 'clpmchn' has service(s) in warning state: 'npcd'
 ```
 
-# Installation
+## Installation
+
 To install the plugin, move the Python script, the agent configuration and sudo rule into their appropriate directories. The paths may vary, depending on your Linux distribution and architecture. For RPM-based distribtions, proceed with the following steps:
-```
+
+```shell
 # mv check_omd.py /usr/lib64/nagios/plugins
 # mv check_omd-sudo-template /etc/sudoers.d/
 # chmod +x /usr/lib64/nagios/plugins/check_omd.py
@@ -56,33 +65,41 @@ To install the plugin, move the Python script, the agent configuration and sudo 
 ```
 
 When using NRPE, copy the appropriate configuration and restart the daemon:
-```
+
+```shell
 # mv check_omd.cfg /etc/nrpe.d/
 # service nrpe restart
 ```
 
 When using Icinga2, copy the configuration to **ITL** (*Icinga Template Library*), e.g.:
-```
+
+```shell
 # cp check_omd.conf /usr/share/icinga2/include/plugins-contrib.d/
 # service icinga2 restart
 ```
 
 Make sure to alter the sudo configuration to match your OMD site name, e.g.:
-```
+
+```shell
 nrpe ALL = (stankowic) NOPASSWD: /usr/lib64/nagios/plugins/check_omd.py
 ```
 
 It also possible to create a RPM file for your Linux distribution with the RPM spec file:
-```
+
+```shell
 $ rpmbuild -ba nagios-plugins-check_omd.spec
+...
 ```
+
 The RPM spec has been tested on Enterprise Linux 5 to 7, i386 and x86_64. Currently, the RPM package only includes NRPE-related configuration, Icinga2 will follow.
 
-# Configuration
+## Configuration
 
-## Nagios / Icinga 1.x
+### Nagios / Icinga 1.x
+
 Inside Nagios / Icinga you will need to configure a remote check command, e.g. for NRPE:
-```
+
+```text
 #check_nrpe_omd
 define command{
     command_name        check_nrpe_omd
@@ -91,7 +108,8 @@ define command{
 ```
 
 Configure the check for a particular host, e.g.:
-```
+
+```text
 #SRV: omd stankowic
 define service{
         use                             generic-service
@@ -101,9 +119,11 @@ define service{
 }
 ```
 
-## Icinga2
+### Icinga2
+
 Define a service like this:
-```
+
+```text
 apply Service for (SITE => config in host.vars.omd_sites) {
   import "generic-service"
   check_command = "check_omd"
@@ -117,7 +137,8 @@ apply Service for (SITE => config in host.vars.omd_sites) {
 ```
 
 Create ``omd_site`` dictionaries for your hosts and assign the ``app`` variable:
-```
+
+```text
 object Host "st-mon04.stankowic.loc" {
   import "linux-host"
   ...
@@ -132,23 +153,28 @@ object Host "st-mon04.stankowic.loc" {
 ```
 
 Validate the configuration and reload the Icinga2 daemon:
-```
+
+```shell
 # icinga2 daemon -C
 # service icinga2 reload
 ```
 
-# Troubleshooting
-## Plugin not executed as OMD site user
+## Troubleshooting
+
+### Plugin not executed as OMD site user
+
 The plugin will not work if is not executed as site user:
-```
+
+```shell
 $ whoami
 taylor
-$ ./check_omd.py 
+$ ./check_omd.py
 UNKNOWN: unable to check site: 'omd: no such site: taylor' - did you miss running this plugin as OMD site user?
 ```
 
-An error message like this will be displayed if multiple OMD sites are available and you're running the plugin as root:
-```
+An error message like this will be displayed if multiple OMD sites are available and you're running the plugin as `root`:
+
+```shell
 # ./check_omd.py
 UNKOWN: unable to check site, it seems this plugin is executed as root (use OMD site context!)
 ````

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ The following parameters can be specified:
 | `-h` / `--help` | shows help and quits |
 | `-w` / `--warning` | defines one or more services that only should throw a warning if not running (*useful for fragile stuff like npcd*) |
 | `-x` / `--exclude` | excludes a particular service from the check |
+| `-H` / `--heal` | automatically restarts the services that are not running |
 | `--version` | prints programm version and quits |
 
 ## Examples

--- a/check_omd.py
+++ b/check_omd.py
@@ -42,6 +42,7 @@ def get_site_status():
         cmd, stderr=subprocess.PIPE, stdin=subprocess.PIPE, stdout=subprocess.PIPE
     )
     res, err = proc.communicate()
+    err = err.decode('utf-8')
 
     if err:
         if "no such site" in err:

--- a/check_omd.py
+++ b/check_omd.py
@@ -13,6 +13,7 @@ https://github.com/stdevel/check_omd
 from optparse import OptionParser
 import subprocess
 import io
+import sys
 import logging
 
 __version__ = "1.1.1"
@@ -50,13 +51,13 @@ def get_site_status():
                 "running this plugin as OMD site user?".format(err.rstrip()))
         else:
             print("UNKNOWN: unable to check site: '{0}'".format(err.rstrip()))
-        exit(3)
+        sys.exit(3)
     if res:
         #try to find out whether omd was executed as root
         if res.count(bytes("OVERALL", "utf-8")) > 1:
             print("UNKOWN: unable to check site, it seems this plugin is " \
                 "executed as root (use OMD site context!)")
-            exit(3)
+            sys.exit(3)
 
         #check all services
         fail_srvs = []
@@ -80,7 +81,12 @@ def get_site_status():
                         if OPTIONS.heal:
                             cmd = ['omd', 'restart', service]
                             LOGGER.debug("running command '%s'", cmd)
-                            proc = subprocess.Popen(cmd, stderr=subprocess.PIPE, stdin=subprocess.PIPE, stdout=subprocess.PIPE)
+                            proc = subprocess.Popen(
+                                cmd,
+                                stderr=subprocess.PIPE,
+                                stdin=subprocess.PIPE,
+                                stdout=subprocess.PIPE
+                            )
                             res2, err2 = proc.communicate()
                             print("{}".format(res2.rstrip().decode("utf-8")))
                             restarted_srvs.append(service)
@@ -96,21 +102,25 @@ def get_site_status():
                 )
         if OPTIONS.heal:
             if len(restarted_srvs) > 0:
-                print("WARNING: Restarted services on site '{0}': '{1}'".format(site, ' '.join(restarted_srvs)))
-                exit(1)
+                print(
+                    "WARNING: Restarted services on site '{0}': '{1}'".format(
+                        site, ' '.join(restarted_srvs)
+                    )
+                )
+                sys.exit(1)
             else:
-                exit(0)
+                sys.exit(0)
         if len(fail_srvs) == 0 and len(warn_srvs) == 0:
             print("OK: OMD site '{0}' services are running.".format(site))
-            exit(0)
+            sys.exit(0)
         elif len(fail_srvs) > 0:
             print("CRITICAL: OMD site '{0}' has failed service(s): " \
                 "'{1}'".format(site, ' '.join(fail_srvs)))
-            exit(2)
+            sys.exit(2)
         else:
             print("WARNING: OMD site '{0}' has service(s) in warning state: " \
                 "'{1}'".format(site, ' '.join(warn_srvs)))
-            exit(1)
+            sys.exit(1)
 
 
 

--- a/check_omd.py
+++ b/check_omd.py
@@ -10,13 +10,13 @@ OMD site status
 https://github.com/stdevel/check_omd
 """
 
-from optparse import OptionParser
+import argparse
 import subprocess
 import io
 import sys
 import logging
 
-__version__ = "1.1.1"
+__version__ = "1.3.0"
 """
 str: Program version
 """
@@ -26,40 +26,46 @@ logging: Logger instance
 """
 
 
-
 def get_site_status():
     """
     Retrieves a particular site's status
     """
-    #get username
+    # get username
     proc = subprocess.Popen("whoami", stdout=subprocess.PIPE)
     site = proc.stdout.read().rstrip().decode("utf-8")
     LOGGER.debug("It seems like I'm OMD site '%s'", site)
 
-    #get OMD site status
+    # get OMD site status
     cmd = ['omd', 'status', '-b']
     LOGGER.debug("running command '%s'", cmd)
     proc = subprocess.Popen(
-        cmd, stderr=subprocess.PIPE, stdin=subprocess.PIPE, stdout=subprocess.PIPE
+        cmd,
+        stderr=subprocess.PIPE,
+        stdin=subprocess.PIPE,
+        stdout=subprocess.PIPE
     )
     res, err = proc.communicate()
     err = err.decode('utf-8')
 
     if err:
         if "no such site" in err:
-            print("UNKNOWN: unable to check site: '{0}' - did you miss " \
-                "running this plugin as OMD site user?".format(err.rstrip()))
+            print(
+                "UNKNOWN: unable to check site: '{0}' - did you miss "
+                "running this plugin as OMD site user?".format(err.rstrip())
+            )
         else:
             print("UNKNOWN: unable to check site: '{0}'".format(err.rstrip()))
         sys.exit(3)
     if res:
-        #try to find out whether omd was executed as root
+        # try to find out whether omd was executed as root
         if res.count(bytes("OVERALL", "utf-8")) > 1:
-            print("UNKOWN: unable to check site, it seems this plugin is " \
-                "executed as root (use OMD site context!)")
+            print(
+                "UNKOWN: unable to check site, it seems this plugin is "
+                "executed as root (use OMD site context!)"
+            )
             sys.exit(3)
 
-        #check all services
+        # check all services
         fail_srvs = []
         warn_srvs = []
         restarted_srvs = []
@@ -69,11 +75,11 @@ def get_site_status():
             service = line.rstrip().split(" ")[0]
             status = line.rstrip().split(" ")[1]
             if service not in OPTIONS.exclude:
-                #check service
+                # check service
                 if status != "0":
                     if service in OPTIONS.warning:
                         LOGGER.debug(
-                            "%s service marked for warning has failed" \
+                            "%s service marked for warning has failed"
                             " state (%s)", service, status
                         )
                         warn_srvs.append(service)
@@ -93,7 +99,7 @@ def get_site_status():
                         else:
                             fail_srvs.append(service)
                             LOGGER.debug(
-                                "%s service has failed state " \
+                                "%s service has failed state "
                                 "(%s)", service, status
                             )
             else:
@@ -114,56 +120,64 @@ def get_site_status():
             print("OK: OMD site '{0}' services are running.".format(site))
             sys.exit(0)
         elif len(fail_srvs) > 0:
-            print("CRITICAL: OMD site '{0}' has failed service(s): " \
-                "'{1}'".format(site, ' '.join(fail_srvs)))
+            print(
+                "CRITICAL: OMD site '{0}' has failed service(s): "
+                "'{1}'".format(site, ' '.join(fail_srvs))
+            )
             sys.exit(2)
         else:
-            print("WARNING: OMD site '{0}' has service(s) in warning state: " \
-                "'{1}'".format(site, ' '.join(warn_srvs)))
+            print(
+                "WARNING: OMD site '{0}' has service(s) in warning state: "
+                "'{1}'".format(site, ' '.join(warn_srvs))
+            )
             sys.exit(1)
 
 
-
 if __name__ == "__main__":
-    #define description, version and load parser
+    # define description, version and load parser
     DESC = '''%prog is used to check a particular OMD site status. By default,
  the script only checks a site's overall status. It is also possible to exclude
  particular services and only check the remaining services (e.g. rrdcached,
- npcd, icinga, apache, crontab).
+ npcd, icinga, apache, crontab).'''
+    EPILOG = 'See also: https://github.com/stdevel/check_omd'
+    PARSER = argparse.ArgumentParser(description=DESC, epilog=EPILOG)
+    PARSER.add_argument('--version', action='version', version=__version__)
 
-Checkout the GitHub page for updates: https://github.com/stdevel/check_omd'''
-    PARSER = OptionParser(description=DESC, version=__version__)
+    # define option groups
+    GEN_OPTS = PARSER.add_argument_group("generic arguments")
+    FILTER_OPTS = PARSER.add_argument_group("filter arguments")
 
-    #-d / --debug
-    PARSER.add_option(
+    # -d / --debug
+    GEN_OPTS.add_argument(
         "-d", "--debug", dest="debug", default=False, action="store_true",
         help="enable debugging outputs (default: no)"
     )
 
-    #-e / --exclude
-    PARSER.add_option(
-        "-x", "--exclude", dest="exclude", default=["OVERALL"],
-        action="append", metavar="SERVICE", help="defines one or more " \
-            "services that should be excluded (default: none)"
+    # -H / --heal
+    FILTER_OPTS.add_argument(
+        "-H", "--heal", dest="heal", default=False, action="store_true",
+        help="automatically restarts failed services (default: no)"
     )
 
-    #-w / --warning
-    PARSER.add_option(
+    # -e / --exclude
+    FILTER_OPTS.add_argument(
+        "-x", "--exclude", dest="exclude", default=["OVERALL"],
+        action="append", metavar="SERVICE", help="defines one or more "
+        "services that should be excluded (default: none)"
+    )
+
+    # -w / --warning
+    FILTER_OPTS.add_argument(
         "-w", "--warning", dest="warning", default=[""], action="append",
-        metavar="SERVICE", help="defines one or more services that only " \
-        "should throw a warning if not running (useful for fragile stuff " \
+        metavar="SERVICE", help="defines one or more services that only "
+        "should throw a warning if not running (useful for fragile stuff "
         "like npcd, default: none)"
     )
-    #-H/ --heal
-    PARSER.add_option(
-        "-H", "--heal", dest="heal", default=False, action="store_true",
-        help="automatically restarts the services that are not running (default: no)"
-    )
 
-    #parse arguments
-    (OPTIONS, ARGS) = PARSER.parse_args()
+    # parse arguments
+    OPTIONS = PARSER.parse_args()
 
-    #set logging level
+    # set logging level
     logging.basicConfig()
     if OPTIONS.debug:
         LOGGER.setLevel(logging.DEBUG)
@@ -172,5 +186,5 @@ Checkout the GitHub page for updates: https://github.com/stdevel/check_omd'''
 
     LOGGER.debug("OPTIONS: %s", OPTIONS)
 
-    #check site status
+    # check site status
     get_site_status()

--- a/test/README.md
+++ b/test/README.md
@@ -1,0 +1,28 @@
+# test
+
+This repository contains a [Vagrantbox](Vagrantfile) for checking the plugin.
+
+In order to run the tests, you will need:
+
+- Python
+- [`testinfra`](https://pypi.org/project/testinfra)
+- [`pytest`](https://pypi.org/project/pytest)
+- [Vagrant](https://vagrantup.com)
+- A supported hypervisor, such as [Oracle VirtualBox](https://virtualbox.org)
+
+## Procedure
+
+Open a shell, move to this folder an run the following command to create the testing VM:
+
+```shell
+$ vagrant up
+```
+
+This will take a couple of minutes, as a CentOS 7 template is downloaded and deployed. It will also automatically install and configure OMD.
+
+Afterwards, create a SSH configuration and run the tests using `pytest`:
+
+```shell
+$ vagrant ssh-config > .vagrant/ssh_config
+$ py.test --connection=ssh --ssh-config .vagrant/ssh_config --hosts=omd test_plugin.py --sudo
+```

--- a/test/README.md
+++ b/test/README.md
@@ -16,6 +16,7 @@ Open a shell, move to this folder an run the following command to create the tes
 
 ```shell
 $ vagrant up
+...
 ```
 
 This will take a couple of minutes, as a CentOS 7 template is downloaded and deployed. It will also automatically install and configure OMD.
@@ -25,4 +26,6 @@ Afterwards, create a SSH configuration and run the tests using `pytest`:
 ```shell
 $ vagrant ssh-config > .vagrant/ssh_config
 $ py.test --connection=ssh --ssh-config .vagrant/ssh_config --hosts=omd test_plugin.py --sudo
+...
+=== 3 passed in 4.01s ===
 ```

--- a/test/Vagrantfile
+++ b/test/Vagrantfile
@@ -1,0 +1,14 @@
+Vagrant.configure("2") do |config|
+  config.vm.define "omd" do |omd|
+    omd.vm.hostname = "omd"
+    omd.vm.box = "generic/centos7"
+    # define port forwardings for external tests
+    omd.vm.network "forwarded_port", guest: 443, host: 8443
+    # install and configure OMD
+    omd.vm.synced_folder ".", "/vagrant", type: "rsync"
+    omd.vm.provision "ansible_local" do |ansible|
+      ansible.playbook = "omd.yml"
+      ansible.galaxy_role_file = "requirements.yml"
+    end
+  end
+end

--- a/test/omd.yml
+++ b/test/omd.yml
@@ -1,0 +1,32 @@
+---
+- name: Configure OMD testing machine
+  hosts: all
+  become: true
+  pre_tasks:
+    - name: Install requirements
+      yum:
+        name:
+          - git
+          - python3
+
+  post_tasks:
+    - name: Disable firewall
+      service:
+        name: firewalld
+        state: stopped
+        enabled: false
+
+    - name: Install plugin
+      git:
+        repo: https://github.com/stdevel/check_omd.git
+        dest: /opt/check_omd
+
+  roles:
+    - role: stdevel.omd
+      omd_sites:
+        - name: icinga2
+          core: icinga2
+          default_gui: thruk
+          thruk_cookie_auth: false
+          remove_nagios_protection: false
+          admin_password: omd

--- a/test/requirements.yml
+++ b/test/requirements.yml
@@ -1,0 +1,4 @@
+---
+roles:
+  - name: stdevel.omd
+    version: 1.2.0

--- a/test/test_plugin.py
+++ b/test/test_plugin.py
@@ -1,0 +1,43 @@
+"""
+Plugin unit tests
+"""
+import os
+
+def test_exclude(host):
+    """
+    Check if services can be excluded
+    """
+    with host.sudo("icinga2"):
+        # stop rrdcached
+        host.run("omd stop rrdcached")
+        cmd_status = host.run(
+            "python3 /opt/check_omd/check_omd.py -x rrdcached"
+        )
+        assert cmd_status.rc == 0
+
+
+def test_warning(host):
+    """
+    Check if critical services can be limited to warnings
+    """
+    with host.sudo("icinga2"):
+        # stop rrdcached
+        host.run("omd stop rrdcached")
+        cmd_status = host.run(
+            "python3 /opt/check_omd/check_omd.py -w rrdcached"
+        )
+        assert cmd_status.rc == 1
+
+
+def test_heal(host):
+    """
+    Check if crashed services can be restarted
+    """
+    with host.sudo("icinga2"):
+        # stop rrdcached
+        host.run("omd stop rrdcached")
+        cmd_status = host.run(
+            "python3 /opt/check_omd/check_omd.py -H"
+        )
+        assert cmd_status.rc == 1
+        assert "restarted service" in cmd_status.stdout.strip().lower()

--- a/test/test_plugin.py
+++ b/test/test_plugin.py
@@ -1,7 +1,7 @@
 """
 Plugin unit tests
 """
-import os
+
 
 def test_exclude(host):
     """


### PR DESCRIPTION
Hi,
I updated the script to python3 and added a "--heal" option to automatically restart OMD services if they are stopped.

We use this with a cronjob that executes the script every minute and writes the output to a logfile if a service was restarted.