### PR TITLE
Added timeout and lockfile functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ The following parameters can be specified:
 | `-w` / `--warning` | defines one or more services that only should throw a warning if not running (*useful for fragile stuff like npcd*) |
 | `-x` / `--exclude` | excludes a particular service from the check |
 | `-H` / `--heal` | automatically restarts the services that are not running |
+| `-t` / `--timeout` | after how many seconds a process should run into a timeout |
 | `--version` | prints programm version and quits |
 
 ## Examples

--- a/README.md
+++ b/README.md
@@ -178,4 +178,10 @@ An error message like this will be displayed if multiple OMD sites are available
 ```shell
 # ./check_omd.py
 UNKOWN: unable to check site, it seems this plugin is executed as root (use OMD site context!)
-````
+```
+
+## Contributors
+
+Thanks a lot for your support:
+
+- lgmu

--- a/check_omd.py
+++ b/check_omd.py
@@ -15,8 +15,11 @@ import subprocess
 import io
 import sys
 import logging
+import stat
+import os.path
+import time
 
-__version__ = "1.3.0"
+__version__ = "1.4.0"
 """
 str: Program version
 """
@@ -25,29 +28,33 @@ LOGGER = logging.getLogger('check_omd')
 logging: Logger instance
 """
 
+def raise_timeout(cmd, timeout):
+    print ("CRITICAL - executing command '{}' exceeded {} seconds timeout".format(" ".join(cmd), timeout))
+    if OPTIONS.heal:
+        os.remove(lockfile)
+        LOGGER.debug("removing lockfile %s", lockfile)
+    sys.exit(2)
 
 def get_site_status():
     """
     Retrieves a particular site's status
     """
     # get username
-    proc = subprocess.Popen("whoami", stdout=subprocess.PIPE)
-    site = proc.stdout.read().rstrip().decode("utf-8")
+    proc = subprocess.run(["whoami"], stdout=subprocess.PIPE)
+    site = proc.stdout.decode('utf-8').rstrip()
     LOGGER.debug("It seems like I'm OMD site '%s'", site)
 
     # get OMD site status
     cmd = ['omd', 'status', '-b']
     LOGGER.debug("running command '%s'", cmd)
-    proc = subprocess.Popen(
-        cmd,
-        stderr=subprocess.PIPE,
-        stdin=subprocess.PIPE,
-        stdout=subprocess.PIPE
-    )
-    res, err = proc.communicate()
-    err = err.decode('utf-8')
 
-    if err:
+    try:
+        proc = subprocess.run(cmd,timeout=OPTIONS.timeout,stdout=subprocess.PIPE,stderr=subprocess.PIPE)
+    except subprocess.TimeoutExpired:
+        raise_timeout(cmd,timeout=OPTIONS.timeout)
+
+    if proc.stderr:
+        err = proc.stderr.decode('utf-8')
         if "no such site" in err:
             print(
                 "UNKNOWN: unable to check site: '{0}' - did you miss "
@@ -55,23 +62,24 @@ def get_site_status():
             )
         else:
             print("UNKNOWN: unable to check site: '{0}'".format(err.rstrip()))
-        sys.exit(3)
-    if res:
+        return 3
+
+    if proc.stdout:
         # try to find out whether omd was executed as root
-        if res.count(bytes("OVERALL", "utf-8")) > 1:
+        if proc.stdout.count(bytes("OVERALL", "utf-8")) > 1:
             print(
-                "UNKOWN: unable to check site, it seems this plugin is "
+                "UNKNOWN: unable to check site, it seems this plugin is "
                 "executed as root (use OMD site context!)"
             )
-            sys.exit(3)
+            return 3
 
         # check all services
         fail_srvs = []
         warn_srvs = []
         restarted_srvs = []
 
-        LOGGER.debug("Got result '%s'", res)
-        for line in io.StringIO(res.decode('utf-8')):
+        LOGGER.debug("Got result '%s'", proc.stdout)
+        for line in io.StringIO(proc.stdout.decode('utf-8')):
             service = line.rstrip().split(" ")[0]
             status = line.rstrip().split(" ")[1]
             if service not in OPTIONS.exclude:
@@ -87,15 +95,18 @@ def get_site_status():
                         if OPTIONS.heal:
                             cmd = ['omd', 'restart', service]
                             LOGGER.debug("running command '%s'", cmd)
-                            proc = subprocess.Popen(
-                                cmd,
-                                stderr=subprocess.PIPE,
-                                stdin=subprocess.PIPE,
-                                stdout=subprocess.PIPE
-                            )
-                            res2, err2 = proc.communicate()
-                            print("{}".format(res2.rstrip().decode("utf-8")))
-                            restarted_srvs.append(service)
+                            try:
+                                proc = subprocess.run(cmd,timeout=OPTIONS.timeout)
+                            except subprocess.TimeoutExpired:
+                                raise_timeout(cmd,OPTIONS.timeout)
+
+                            if proc.returncode == 0:
+                                restarted_srvs.append(service)
+                                LOGGER.debug("%s restarted successfully", service)
+                            else:
+                                fail_srvs.append(service)
+                                LOGGER.debug("%s restart FAILED", service)
+
                         else:
                             fail_srvs.append(service)
                             LOGGER.debug(
@@ -107,33 +118,44 @@ def get_site_status():
                     "Ignoring '%s' as it's blacklisted.", service
                 )
         if OPTIONS.heal:
-            if len(restarted_srvs) > 0:
-                print(
-                    "WARNING: Restarted services on site '{0}': '{1}'".format(
-                        site, ' '.join(restarted_srvs)
+            if len(fail_srvs) == 0 and len(restarted_srvs) == 0:
+               return 0
+            returncode = 1
+            if len(fail_srvs) > 0:
+                print("CRITICAL - could not restart {} service(s) on site '{}': '{}'".format(
+                    len(fail_srvs), site, ' '.join(fail_srvs)
                     )
                 )
-                sys.exit(1)
-            else:
-                sys.exit(0)
+                returncode = 2
+            if len(restarted_srvs) > 0:
+                print(
+                    "WARNING: Restarted {} service(s) on site '{}': '{}'".format(
+                        len(restarted_srvs), site, ' '.join(restarted_srvs)
+                    )
+                )
+            return returncode
+
         if len(fail_srvs) == 0 and len(warn_srvs) == 0:
             print("OK: OMD site '{0}' services are running.".format(site))
-            sys.exit(0)
+            return 0
         elif len(fail_srvs) > 0:
             print(
                 "CRITICAL: OMD site '{0}' has failed service(s): "
                 "'{1}'".format(site, ' '.join(fail_srvs))
             )
-            sys.exit(2)
+            return 2
         else:
             print(
                 "WARNING: OMD site '{0}' has service(s) in warning state: "
                 "'{1}'".format(site, ' '.join(warn_srvs))
             )
-            sys.exit(1)
+            return 1
 
 
 if __name__ == "__main__":
+    if sys.version_info[0] < 3 or (sys.version_info[0] == 3 and sys.version_info[1] < 6):
+        print ("Unsupported python version, 3.6 required, you have {}".format(sys.version))
+        sys.exit(2)
     # define description, version and load parser
     DESC = '''%prog is used to check a particular OMD site status. By default,
  the script only checks a site's overall status. It is also possible to exclude
@@ -174,6 +196,12 @@ if __name__ == "__main__":
         "like npcd, default: none)"
     )
 
+    # -t / --timeout
+    FILTER_OPTS.add_argument(
+        "-t", "--timeout", dest="timeout", default=1800, action="store",
+        help="after how many seconds a process should run into a timeout", type=int
+    )
+
     # parse arguments
     OPTIONS = PARSER.parse_args()
 
@@ -186,5 +214,27 @@ if __name__ == "__main__":
 
     LOGGER.debug("OPTIONS: %s", OPTIONS)
 
-    # check site status
-    get_site_status()
+    lockfile = '/tmp/check_omd.lock'
+
+    if OPTIONS.heal:
+        if (os.path.isfile(lockfile)):
+            fileage = int(time.time() - os.stat(lockfile)[stat.ST_MTIME])
+            LOGGER.debug("%s is %s seconds old", lockfile, fileage)
+            if fileage > OPTIONS.timeout:
+                print ("Lockfile too old, deleting lockfile")
+                os.remove(lockfile)
+                sys.exit(0)
+            print ("CRITICAL - Lockfile exists, exit program")
+            sys.exit(2)
+        else:
+            f = open(lockfile, 'x')
+            f.close()
+            LOGGER.debug("created lockfile %s", lockfile)
+            # check site status
+            exitcode = get_site_status()
+            os.remove(lockfile)
+            LOGGER.debug("removing lockfile %s", lockfile)
+            sys.exit(exitcode)
+    else:
+        exitcode = get_site_status()
+        sys.exit(exitcode)

--- a/check_omd.py
+++ b/check_omd.py
@@ -128,7 +128,7 @@ def get_site_status():
                 )
         if OPTIONS.heal:
             if len(fail_srvs) == 0 and len(restarted_srvs) == 0:
-               return 0
+                return 0
             returncode = 1
             if len(fail_srvs) > 0:
                 _count = len(fail_srvs)
@@ -238,8 +238,8 @@ if __name__ == "__main__":
             print ("CRITICAL - Lockfile exists, exit program")
             sys.exit(2)
         else:
-            f = open(lockfile, 'x')
-            f.close()
+            with open(LOCKFILE, 'x', encoding="utf8") as f:
+                f.close()
             LOGGER.debug("created lockfile %s", LOCKFILE)
             # check site status
             EXITCODE = get_site_status()

--- a/check_omd.py
+++ b/check_omd.py
@@ -19,7 +19,7 @@ import stat
 import os.path
 import time
 
-__version__ = "1.4.0"
+__version__ = "1.3.0"
 """
 str: Program version
 """

--- a/check_omd.py
+++ b/check_omd.py
@@ -35,8 +35,8 @@ def raise_timeout(cmd, timeout):
     _cmd = " ".join(cmd)
     print(f"CRITICAL - executing command '{_cmd}' exceeded {timeout} seconds timeout")
     if OPTIONS.heal:
-        os.remove(lockfile)
-        LOGGER.debug("removing lockfile %s", lockfile)
+        os.remove(LOCKFILE)
+        LOGGER.debug("removing LOCKFILE %s", LOCKFILE)
     sys.exit(2)
 
 def get_site_status():
@@ -225,27 +225,27 @@ if __name__ == "__main__":
 
     LOGGER.debug("OPTIONS: %s", OPTIONS)
 
-    lockfile = '/tmp/check_omd.lock'
+    LOCKFILE = '/tmp/check_omd.lock'
 
     if OPTIONS.heal:
-        if (os.path.isfile(lockfile)):
-            fileage = int(time.time() - os.stat(lockfile)[stat.ST_MTIME])
-            LOGGER.debug("%s is %s seconds old", lockfile, fileage)
+        if os.path.isfile(LOCKFILE):
+            fileage = int(time.time() - os.stat(LOCKFILE)[stat.ST_MTIME])
+            LOGGER.debug("%s is %s seconds old", LOCKFILE, fileage)
             if fileage > OPTIONS.timeout:
                 print ("Lockfile too old, deleting lockfile")
-                os.remove(lockfile)
+                os.remove(LOCKFILE)
                 sys.exit(0)
             print ("CRITICAL - Lockfile exists, exit program")
             sys.exit(2)
         else:
             f = open(lockfile, 'x')
             f.close()
-            LOGGER.debug("created lockfile %s", lockfile)
+            LOGGER.debug("created lockfile %s", LOCKFILE)
             # check site status
-            exitcode = get_site_status()
-            os.remove(lockfile)
-            LOGGER.debug("removing lockfile %s", lockfile)
-            sys.exit(exitcode)
+            EXITCODE = get_site_status()
+            os.remove(LOCKFILE)
+            LOGGER.debug("removing lockfile %s", LOCKFILE)
+            sys.exit(EXITCODE)
     else:
-        exitcode = get_site_status()
-        sys.exit(exitcode)
+        EXITCODE = get_site_status()
+        sys.exit(EXITCODE)

--- a/check_omd.py
+++ b/check_omd.py
@@ -44,7 +44,7 @@ def get_site_status():
     Retrieves a particular site's status
     """
     # get username
-    proc = subprocess.run(["whoami"], stdout=subprocess.PIPE)
+    proc = subprocess.run(["whoami"], stdout=subprocess.PIPE, check=False)
     site = proc.stdout.decode('utf-8').rstrip()
     LOGGER.debug("It seems like I'm OMD site '%s'", site)
 
@@ -53,7 +53,13 @@ def get_site_status():
     LOGGER.debug("running command '%s'", cmd)
 
     try:
-        proc = subprocess.run(cmd,timeout=OPTIONS.timeout,stdout=subprocess.PIPE,stderr=subprocess.PIPE)
+        proc = subprocess.run(
+            cmd,
+            timeout=OPTIONS.timeout,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            check=False
+        )
     except subprocess.TimeoutExpired:
         raise_timeout(cmd,timeout=OPTIONS.timeout)
 
@@ -98,7 +104,7 @@ def get_site_status():
                             cmd = ['omd', 'restart', service]
                             LOGGER.debug("running command '%s'", cmd)
                             try:
-                                proc = subprocess.run(cmd,timeout=OPTIONS.timeout)
+                                proc = subprocess.run(cmd,timeout=OPTIONS.timeout, check=False)
                             except subprocess.TimeoutExpired:
                                 raise_timeout(cmd,OPTIONS.timeout)
 

--- a/check_omd.py
+++ b/check_omd.py
@@ -32,6 +32,8 @@ def raise_timeout(cmd, timeout):
     """
     Raises a timeout and exits the program
     """
+    _cmd = " ".join(cmd)
+    print(f"CRITICAL - executing command '{_cmd}' exceeded {timeout} seconds timeout")
     if OPTIONS.heal:
         os.remove(lockfile)
         LOGGER.debug("removing lockfile %s", lockfile)
@@ -58,13 +60,11 @@ def get_site_status():
     if proc.stderr:
         err = proc.stderr.decode('utf-8')
         if "no such site" in err:
-            print(
-                "UNKNOWN: unable to check site: '{0}' - did you miss "
-                "running this plugin as OMD site user?".format(err.rstrip())
+            print(f"UNKNOWN: unable to check site: '{err.rstrip()}' - did you miss "
+                "running this plugin as OMD site user?"
             )
         else:
-            print("UNKNOWN: unable to check site: '{0}'".format(err.rstrip()))
-        return 3
+            print(f"UNKNOWN: unable to check site: '{err.rstrip()}'")
 
     if proc.stdout:
         # try to find out whether omd was executed as root
@@ -124,39 +124,39 @@ def get_site_status():
                return 0
             returncode = 1
             if len(fail_srvs) > 0:
-                print("CRITICAL - could not restart {} service(s) on site '{}': '{}'".format(
-                    len(fail_srvs), site, ' '.join(fail_srvs)
-                    )
+                _count = len(fail_srvs)
+                _srvs = ' '.join(fail_srvs)
+                print(
+                    f"CRITICAL - could not restart {_count} service(s) on site '{site}': '{_srvs}'"
                 )
                 returncode = 2
             if len(restarted_srvs) > 0:
+                _count = len(restarted_srvs)
+                _srvs = ' '.join(restarted_srvs)
                 print(
-                    "WARNING: Restarted {} service(s) on site '{}': '{}'".format(
-                        len(restarted_srvs), site, ' '.join(restarted_srvs)
-                    )
+                    f"WARNING: Restarted {_count} service(s) on site '{site}': '{_srvs}'"
                 )
             return returncode
 
         if len(fail_srvs) == 0 and len(warn_srvs) == 0:
-            print("OK: OMD site '{0}' services are running.".format(site))
-            return 0
+            print(f"OK: OMD site '{site}' services are running.")
         elif len(fail_srvs) > 0:
+            _services = ' '.join(fail_srvs)
             print(
-                "CRITICAL: OMD site '{0}' has failed service(s): "
-                "'{1}'".format(site, ' '.join(fail_srvs))
+                f"CRITICAL: OMD site 'site' has failed service(s): '{_services}'"
             )
             return 2
         else:
+            _services = ' '.join(warn_srvs)
             print(
-                "WARNING: OMD site '{0}' has service(s) in warning state: "
-                "'{1}'".format(site, ' '.join(warn_srvs))
+                f"WARNING: OMD site 'site' has service(s) in warning state: '{_services}'"
             )
             return 1
 
 
 if __name__ == "__main__":
     if sys.version_info[0] < 3 or (sys.version_info[0] == 3 and sys.version_info[1] < 6):
-        print ("Unsupported python version, 3.6 required, you have {}".format(sys.version))
+        print(f"Unsupported python version, 3.6 required, you have {sys.version}")
         sys.exit(2)
     # define description, version and load parser
     DESC = '''%prog is used to check a particular OMD site status. By default,

--- a/check_omd.py
+++ b/check_omd.py
@@ -71,6 +71,7 @@ def get_site_status():
             )
         else:
             print(f"UNKNOWN: unable to check site: '{err.rstrip()}'")
+        return_code = 3
 
     if proc.stdout:
         # try to find out whether omd was executed as root
@@ -79,7 +80,7 @@ def get_site_status():
                 "UNKNOWN: unable to check site, it seems this plugin is "
                 "executed as root (use OMD site context!)"
             )
-            return 3
+            return_code = 3
 
         # check all services
         fail_srvs = []
@@ -146,18 +147,20 @@ def get_site_status():
 
         if len(fail_srvs) == 0 and len(warn_srvs) == 0:
             print(f"OK: OMD site '{site}' services are running.")
+            return_code = 0
         elif len(fail_srvs) > 0:
             _services = ' '.join(fail_srvs)
             print(
                 f"CRITICAL: OMD site 'site' has failed service(s): '{_services}'"
             )
-            return 2
+            return_code = 2
         else:
             _services = ' '.join(warn_srvs)
             print(
                 f"WARNING: OMD site 'site' has service(s) in warning state: '{_services}'"
             )
-            return 1
+            return_code = 1
+    return return_code
 
 
 if __name__ == "__main__":

--- a/check_omd.py
+++ b/check_omd.py
@@ -29,7 +29,9 @@ logging: Logger instance
 """
 
 def raise_timeout(cmd, timeout):
-    print ("CRITICAL - executing command '{}' exceeded {} seconds timeout".format(" ".join(cmd), timeout))
+    """
+    Raises a timeout and exits the program
+    """
     if OPTIONS.heal:
         os.remove(lockfile)
         LOGGER.debug("removing lockfile %s", lockfile)

--- a/icingaexchange.yml
+++ b/icingaexchange.yml
@@ -7,6 +7,14 @@ target: Operating System
 type: Plugin
 license: gplv3
 releases:
+  - name: 1.3.0
+    description: "Release 1.3.0"
+    files: 
+      - 
+        name: check_omd.py
+        url: "file:///check_omd.py"
+        description: "Release 1.3.0"
+        checksum: a98021ab63ee355088fae4d4692520f6
   - name: 1.2.0
     description: "Release 1.2.0"
     files: 

--- a/nagios-plugins-check_omd.spec
+++ b/nagios-plugins-check_omd.spec
@@ -1,6 +1,6 @@
 Name:           nagios-plugins-check_omd
-Version:        1.1
-Release:        1%{?dist}
+Version:        1.3
+Release:        0%{?dist}
 Summary:        A Nagios / Icinga plugin for checking OMD sites.
 
 Group:          Applications/System
@@ -58,6 +58,12 @@ rm -rf $RPM_BUILD_ROOT
 
 
 %changelog
+* Sat Jul 16 2022 Christian Stankowic <info@cstan.io> - 1.3.0
+- updates to upstream version 1.3.0
+
+* Thu Apr 20 2021 Christian Stankowic <info@cstan.io> - 1.2.0
+- updates to upstream version 1.2.0
+
 * Thu May 31 2018 Christian Stankowic <info@cstan.io> - 1.1.1
 - rebased to upstream version 1.1.1
 


### PR DESCRIPTION
We ran into some issues where a "omd restart naemon" would get stuck because there were changes at the naemon core. At this point the script was also hanging.
That's why I had to remove the proc.communicate that captures stdout and stderr and used a different approach. Also I verify if a service restarted correctly or failed.

Also, there are some really slow systems that take very long to restart naemon, that's why I added a timeout parameter.
We have a cronjob that executes this script every 3 minutes and naemon sometimes takes longer to restart (when you have 100k + services), so I added a lockfile - so it doesn't try to restart it again before the first restart finished.

I tested this on RHEL 7 and 8 with OMD 4 and python 3.6.8